### PR TITLE
Add order change verification for Deck#shuffle test

### DIFF
--- a/src/test/java/domain/DeckTest.java
+++ b/src/test/java/domain/DeckTest.java
@@ -46,4 +46,28 @@ class DeckTest {
         assertEquals(before, deck.cards.size());
         assertFalse(deck.isEmpty());
     }
+
+    @Test
+    void gameSetup_shuffle_actuallyChangesOrder() {
+        Deck deck = new Deck();
+
+        for (int i = 0; i < 20; i++) {
+            Card uniqueCard = new Card(1, TokenColor.DIAMOND, new HashMap<>(), i);
+            deck.addCard(uniqueCard);
+        }
+
+        java.util.List<Card> originalOrder = new java.util.ArrayList<>(deck.cards);
+
+        deck.shuffle();
+
+        boolean orderChanged = false;
+        for (int i = 0; i < originalOrder.size(); i++) {
+            if (originalOrder.get(i) != deck.cards.get(i)) {
+                orderChanged = true;
+                break;
+            }
+        }
+
+        assertTrue(orderChanged, "Shuffle should actively change the order of cards in the deck");
+    }
 }


### PR DESCRIPTION
This pull request adds a new unit test to verify that the `shuffle` method in the `Deck` class actually changes the order of cards, not just their count. This helps ensure the shuffle logic is functioning as intended.

Testing improvements:

* Added a test method `gameSetup_shuffle_actuallyChangesOrder` to `DeckTest.java` to confirm that shuffling a deck changes the order of cards.

**Closes #65**